### PR TITLE
Fix the sarcasm function so the first letter of each word is lowercase

### DIFF
--- a/bin/message.js
+++ b/bin/message.js
@@ -103,7 +103,7 @@ module.exports = {
     return text
       .split("")
       .map((item, index) =>
-        index % 2 === 0 ? item.toUpperCase() : item.toLowerCase()
+        index % 2 === 1 ? item.toUpperCase() : item.toLowerCase()
       )
       .join("");
   },


### PR DESCRIPTION
The original function didn't have the correct casing. Testing examples:

Before:
```
root@448195f9428d:/usr/src/app# node lol.js
ThIs iS A TeSt
```

After these changes:
```
root@448195f9428d:/usr/src/app# node lol.js
tHiS Is a tEsT
```